### PR TITLE
Implement file icon display

### DIFF
--- a/src/components/FileUpload.vue
+++ b/src/components/FileUpload.vue
@@ -1,33 +1,42 @@
 <script setup>
-import { ref } from 'vue'
-import { useOptionsStore } from '../stores/options'
-import { useUiStore } from '../stores/ui'
+import { ref, computed } from "vue";
+import { useOptionsStore } from "../stores/options";
+import { useUiStore } from "../stores/ui";
 
-const store = useOptionsStore()
-const ui = useUiStore()
+const store = useOptionsStore();
+const ui = useUiStore();
 
-const dragActive = ref(false)
-const input = ref(null)
+const dragActive = ref(false);
+const input = ref(null);
+
+const icon = computed(() => {
+  if (!store.file) return "";
+  const ext = store.file.name.split(".").pop().toLowerCase();
+  if (ext === "zip") return "📦";
+  if (ext === "gtp") return "⬆️";
+  if (ext === "gbr") return "📄";
+  return "📄";
+});
 
 function handleFiles(files) {
-  if (!files.length) return
-  const file = files[0]
-  const ext = file.name.split('.').pop().toLowerCase()
-  if (!['gtp', 'gbr', 'zip'].includes(ext)) {
-    ui.addToast('Unsupported file type')
-    return
+  if (!files.length) return;
+  const file = files[0];
+  const ext = file.name.split(".").pop().toLowerCase();
+  if (!["gtp", "gbr", "zip"].includes(ext)) {
+    ui.addToast("Unsupported file type");
+    return;
   }
   if (file.size > 10 * 1024 * 1024) {
-    ui.addToast('File too large')
-    return
+    ui.addToast("File too large");
+    return;
   }
-  store.setFile(file)
+  store.setFile(file);
 }
 
 function onDrop(e) {
-  e.preventDefault()
-  dragActive.value = false
-  handleFiles(e.dataTransfer.files)
+  e.preventDefault();
+  dragActive.value = false;
+  handleFiles(e.dataTransfer.files);
 }
 </script>
 
@@ -51,9 +60,17 @@ function onDrop(e) {
       class="underline text-blue-600"
       type="button"
       @click="input.click()"
-    >Browse</button>
-    <p v-if="store.file" class="mt-2 text-sm text-gray-700">
-      {{ store.file.name }} ({{ (store.file.size / 1024).toFixed(1) }} kB)
+    >
+      Browse
+    </button>
+    <p
+      v-if="store.file"
+      class="mt-2 text-sm text-gray-700 flex items-center justify-center space-x-1"
+    >
+      <span>{{ icon }}</span>
+      <span>
+        {{ store.file.name }} ({{ (store.file.size / 1024).toFixed(1) }} kB)
+      </span>
     </p>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- show a simple icon for GTP, GBR or ZIP files

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68741afd12cc832b86476491e5549450