### PR TITLE
Add basic SVG Gerber viewer

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,7 @@ import Header from './components/Header.vue'
 import FileUpload from './components/FileUpload.vue'
 import OptionsForm from './components/OptionsForm.vue'
 import ConvertButton from './components/ConvertButton.vue'
+import GerberViewer from './components/GerberViewer.vue'
 import ToastContainer from './components/ToastContainer.vue'
 </script>
 
@@ -13,6 +14,7 @@ import ToastContainer from './components/ToastContainer.vue'
       <div class="w-full max-w-xl space-y-6">
         <FileUpload />
         <OptionsForm />
+        <GerberViewer />
         <ConvertButton />
       </div>
     </main>

--- a/src/components/GerberViewer.vue
+++ b/src/components/GerberViewer.vue
@@ -1,0 +1,91 @@
+<script setup>
+import { ref, watch, computed } from 'vue'
+import { useOptionsStore } from '../stores/options'
+
+const store = useOptionsStore()
+const view = ref(null)
+const pan = ref({ x: 0, y: 0 })
+const zoom = ref(1)
+const dragging = ref(false)
+const last = ref({ x: 0, y: 0 })
+
+const bbox = computed(() => store.bbox)
+
+function onWheel(e) {
+  e.preventDefault()
+  const delta = e.deltaY > 0 ? 0.9 : 1.1
+  zoom.value *= delta
+}
+function onDown(e) {
+  dragging.value = true
+  last.value = { x: e.clientX, y: e.clientY }
+}
+function onMove(e) {
+  if (!dragging.value) return
+  pan.value.x += (e.clientX - last.value.x)
+  pan.value.y += (e.clientY - last.value.y)
+  last.value = { x: e.clientX, y: e.clientY }
+}
+function onUp() {
+  dragging.value = false
+}
+
+watch(
+  () => [store.primitives, store.scale, store.dpi, store.invert],
+  () => {
+    // trigger re-render by updating zoom slightly
+    zoom.value = zoom.value * 1
+  }
+)
+</script>
+
+<template>
+  <div class="border rounded relative overflow-hidden select-none">
+    <svg
+      ref="view"
+      :width="bbox?.width || 100"
+      :height="bbox?.height || 100"
+      @wheel="onWheel"
+      @mousedown="onDown"
+      @mousemove="onMove"
+      @mouseup="onUp"
+      @mouseleave="onUp"
+    >
+      <g
+        :transform="`translate(${pan.x},${pan.y}) scale(${zoom})`"
+        stroke-width="1"
+        fill="none"
+      >
+        <template v-for="(p, i) in store.primitives" :key="i">
+          <line
+            v-if="p.type === 'line'"
+            :x1="p.x1"
+            :y1="p.y1"
+            :x2="p.x2"
+            :y2="p.y2"
+            stroke="gray"
+          />
+          <circle
+            v-else-if="p.type === 'circle' || p.type === 'flash'"
+            :cx="p.cx"
+            :cy="p.cy"
+            :r="p.r || 0.5"
+            stroke="skyblue"
+          />
+        </template>
+      </g>
+    </svg>
+    <div v-if="bbox" class="absolute bottom-1 right-1 text-xs bg-white bg-opacity-75 p-1 rounded">
+      {{ bbox.width.toFixed(2) }} x {{ bbox.height.toFixed(2) }} mm,
+      {{ store.primitives.length }} primitives
+    </div>
+  </div>
+</template>
+
+<style scoped>
+svg {
+  width: 100%;
+  height: 400px;
+  cursor: grab;
+}
+</style>

--- a/src/lib/computeBBox.js
+++ b/src/lib/computeBBox.js
@@ -1,0 +1,35 @@
+export function computeBBox(primitives) {
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  for (const p of primitives) {
+    switch (p.type) {
+      case 'line':
+        minX = Math.min(minX, p.x1, p.x2)
+        minY = Math.min(minY, p.y1, p.y2)
+        maxX = Math.max(maxX, p.x1, p.x2)
+        maxY = Math.max(maxY, p.y1, p.y2)
+        break
+      case 'flash':
+      case 'circle':
+        const r = p.r || 0
+        minX = Math.min(minX, p.cx - r)
+        minY = Math.min(minY, p.cy - r)
+        maxX = Math.max(maxX, p.cx + r)
+        maxY = Math.max(maxY, p.cy + r)
+        break
+      default:
+        break
+    }
+  }
+  if (!isFinite(minX)) return null
+  return {
+    minX,
+    minY,
+    maxX,
+    maxY,
+    width: maxX - minX,
+    height: maxY - minY,
+  }
+}

--- a/src/stores/options.js
+++ b/src/stores/options.js
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { parseGerber } from '../lib/parseGerber'
+import { computeBBox } from '../lib/computeBBox'
 import { useUiStore } from './ui'
 
 export const useOptionsStore = defineStore('options', {
@@ -11,6 +12,7 @@ export const useOptionsStore = defineStore('options', {
     dpi: 300,
     invert: false,
     primitives: [],
+    bbox: null,
   }),
   getters: {
     isValid: (state) =>
@@ -28,8 +30,10 @@ export const useOptionsStore = defineStore('options', {
       reader.onload = () => {
         try {
           this.primitives = parseGerber(reader.result)
+          this.bbox = computeBBox(this.primitives)
         } catch (e) {
           this.primitives = []
+          this.bbox = null
           useUiStore().addToast(e.message)
         }
       }


### PR DESCRIPTION
## Summary
- show preview using new `GerberViewer` component
- compute drawing bounds with `computeBBox`
- store bounding box in options store

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6874213f9fbc832b8bca1c26b33edea6