### PR TITLE
Implement basic DXF export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "gerb-to-cut",
       "version": "0.0.0",
       "dependencies": {
+        "@tarikjabiri/dxf": "^2.8.9",
         "@tracespace/parser": "^5.0.0-next.0",
         "vue": "^3.4.0"
       },
@@ -1090,6 +1091,19 @@
         "@tailwindcss/oxide": "4.1.11",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.11"
+      }
+    },
+    "node_modules/@tarikjabiri/dxf": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/@tarikjabiri/dxf/-/dxf-2.8.9.tgz",
+      "integrity": "sha512-ckBkEsWdlFTvqm2ARm23xX3EVouYsnNuZWS7P/oec1WCGTjzdd9jhmtQqyhh7TQSvQo4HunbDv4Vxiv07/8zsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16",
+        "pnpm": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/dxfjs"
       }
     },
     "node_modules/@tracespace/parser": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tarikjabiri/dxf": "^2.8.9",
     "@tracespace/parser": "^5.0.0-next.0",
     "vue": "^3.4.0"
   },

--- a/src/components/ConvertButton.vue
+++ b/src/components/ConvertButton.vue
@@ -1,12 +1,16 @@
 <script setup>
 import { useOptionsStore } from '../stores/options'
 import { useUiStore } from '../stores/ui'
+import { generateDxf } from '../lib/dxf.service'
 
 const store = useOptionsStore()
 const ui = useUiStore()
 
 function convert() {
-  const dxf = '0\nSECTION\n2\nENTITIES\n0\nENDSEC\n0\nEOF\n'
+  const layers = [
+    { name: store.layer || 'Layer1', primitives: store.primitives }
+  ]
+  const dxf = generateDxf(layers, { units: store.units, scale: store.scale })
   const blob = new Blob([dxf], { type: 'application/dxf' })
   const url = URL.createObjectURL(blob)
   const name = store.file ? store.file.name.replace(/\.[^.]+$/, '.dxf') : 'output.dxf'

--- a/src/lib/dxf.service.js
+++ b/src/lib/dxf.service.js
@@ -1,0 +1,38 @@
+import { DxfWriter, point3d, Units } from '@tarikjabiri/dxf'
+
+/**
+ * Generate DXF string from primitives grouped by layer.
+ * @param {Array<{name:string, primitives:any[]}>} layers
+ * @param {{units:'mm'|'inch', scale:number, invert?:boolean}} options
+ * @returns {string}
+ */
+export function generateDxf(layers, options = {}) {
+  const writer = new DxfWriter()
+  const { units = 'mm', scale = 1 } = options
+  const insUnits = units === 'mm' ? Units.Millimeters : Units.Inches
+  writer.setUnits(insUnits)
+  for (const { name, primitives } of layers) {
+    writer.addLayer(name, 7, 'CONTINUOUS')
+    writer.setCurrentLayerName(name)
+    for (const p of primitives) {
+      switch (p.type) {
+        case 'line':
+          writer.addLine(
+            point3d(p.x1 * scale, p.y1 * scale),
+            point3d(p.x2 * scale, p.y2 * scale)
+          )
+          break
+        case 'circle':
+        case 'flash':
+          writer.addCircle(
+            point3d(p.cx * scale, p.cy * scale),
+            (p.r || 0) * scale
+          )
+          break
+        default:
+          break
+      }
+    }
+  }
+  return writer.stringify()
+}


### PR DESCRIPTION
## Summary
- install `@tarikjabiri/dxf`
- add `generateDxf` service
- use service in ConvertButton

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687422cb4988832b9a350fe3af81132b